### PR TITLE
Re-run CI with new docker image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Build neuron site 🔧
       run: |
         mkdir -p .neuron/output && touch .neuron/output/.nojekyll
-        docker run --env LOCALE_ARCHIVE=/usr/lib/locale/locale-archive  -v $PWD:/notes sridca/neuron  neuron gen --pretty-urls 
+        docker run -v $PWD:/notes sridca/neuron  neuron gen --pretty-urls 
     - name: Deploy to gh-pages 🚀
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
If you merge this, the site should show all notes. Can you test it?

The new docker image has fixed neuron.